### PR TITLE
Release v1.0.4: Architecture refactor, plateau logic fix, docs update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,23 @@ dist/
 build/
 *.egg-info/
 
+# Testing artifacts (since you added pytest)
+.pytest_cache/
+tests/__pycache__/
+
+# PsychoPy specific logs
+*.log
+lastRun.log
+psychopy.log
+
+# OS Junk files (Mac/Windows thumbnails)
+.DS_Store
+Thumbs.db
+
+# Excel lock files (common if opening CSVs while coding)
+~$*.csv
+~$*.xlsx
+
 # WAND Project Data and Output (IMPORTANT)
 data/
 Combined SEQ/

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,7 @@
 {
     "title": "WAND (Working-memory Active-fatigue with N-back Difficulty): A Modular Software Suite for Cognitive Fatigue Research",
-    "version": "1.0.3",
+    "version": "1.0.4",
+    "publication_date": "2025-12-07",
     "description": "An open-source PsychoPy software suite for cognitive fatigue research. It provides a modular N-back framework to classify performance, calibrate stable baselines via plateau detection, and systematically induce active fatigue.",
     "creators": [
         {
@@ -15,7 +16,7 @@
         "N-back",
         "PsychoPy",
         "open source software",
-        "active fatigue",
+        "active cognitive fatigue",
         "cognitive load",
         "experimental psychology"
     ],

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,71 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [1.0.4] - 2025-12-07
+
+### Added
+- **Centralised behavioural analysis module**:  
+  `wand_analysis.py` now contains all Sequential N-back metrics (accuracy, average RT, A′, d′, and pre/post distractor window calculations).  
+  The induction script now delegates all metric computation to this module.
+
+### Changed
+- **Extensive code deduplication and refactoring** (addresses reviewer feedback):
+    - **UI prompts**: Replaced all ad-hoc text input and choice loops with shared helpers  
+      `prompt_text_input()` and `prompt_choice()` in `wand_common.py`.  
+      Used consistently for Participant ID, RNG seed, distractor toggles, etc.
+    - **Unified text-screen system**:  
+      Welcome screens, instruction screens, break screens, summaries, and transitions are now built on a shared `show_text_screen()` helper.
+    - **Response loop unification**:  
+      All Spatial, Dual, and Sequential tasks now use a single centralised `collect_trial_response()` function built on `check_response_keys()`, eliminating duplicated per-frame polling and timing logic.
+    - **Sequence generation merged**:  
+      Sequential image generation is now handled by a single `generate_sequential_image_sequence()` function in `wand_common.py`.
+
+- **Sequential N-back logic standardised**:
+    - Removed old **n−1 misleading lure patterns** from 3-back.  
+    - Both 2-back and 3-back now follow a unified structure:  
+      - ~50% target probability  
+      - Maximum 2 consecutive matches  
+    - Ensures **d′ and A′ comparability across N levels**.
+
+- **Practical installation improvements** (Reviewer 2):
+    - README now explicitly includes **both** `python` **and** `py` commands for Windows.  
+    - Added instructions to upgrade pip inside the virtual environment  
+      (`python -m pip install --upgrade pip` or `py -m pip install --upgrade pip`)  
+      to prevent build failures for `cryptography`, `opencv-python`, and `PyQt6`.
+
+- **Neutral, non-competitive practice framing**:
+    - Practice instructions rewritten to emphasise calibration and rhythm rather than performance.  
+    - Per-block practice feedback now uses qualitative, neutral wording instead of numeric accuracy.  
+    - Removes encouragement of compensatory “score chasing”, preserving fatigue-induction validity.
+
+- **Sequential practice target rate updated**:  
+  Raised from **0.4 → 0.5** to align practice with main induction design and with the scientific description in the documentation.
+
+- **Display configuration hardened**:  
+  Window background colour is now explicitly set to RGB `[-1, -1, -1]` in `params.json`.  
+  Prevents white-on-white rendering issues reported by reviewer.
+
+### Fixed
+- 
+**Sequential Practice Logic Conflict**:  
+  Resolved an edge case in `WAND_practice_plateau.py` where a participant achieving high stability *and* high accuracy simultaneously would trigger the plateau exit condition instead of the intended difficulty promotion. The logic now prioritizes level promotion over plateau termination.
+  **Miscellaneous text visibility issues**:
+    - Forced explicit black background resolves systems where `"black"` is interpreted inconsistently by PsychoPy.
+
+### Removed
+- **Legacy on-screen scoreboards**:
+    - `show_summary()` and `show_final_summary()` removed from the main task flow.  
+      (These previously showed accuracy/d′ during the experiment.)
+    - Participants now receive only neutral instructional text; all metrics are saved to CSV.
+
+- **Obsolete inline metric helpers**:
+    - Old versions of `calculate_accuracy_and_rt`, `calculate_dprime`, `calculate_A_prime`,  
+      and `calculate_sequential_nback_summary` in `WAND_full_induction.py` have been deprecated  
+      in favour of the centralised analysis module.
+
+---
+
+---
 ## [1.0.3] - 2025-10-03
 ### Added
 - `wand_common.py` shared module centralising utilities (grid drawing, jitter, colour mapping, error hook, sequence generators). Both `WAND_full_induction.py` and `WAND_practice_plateau.py` import from this module.

--- a/README_experiment.md
+++ b/README_experiment.md
@@ -15,9 +15,11 @@ For a reproducible environment, it is highly recommended to use a virtual enviro
 
 ## File Structure
 
-WAND_full_induction.py: Main script for the fatigue induction experiment.
-Abstract Stimuli/apophysis/: Folder containing at least 24 complex 3D fractal PNG images generated with Apophysis software for N-back tasks (included in the repository).
-data/: Output directory for results (auto-created during execution).
+- `WAND_full_induction.py`: Main script for the fatigue induction experiment.
+- `wand_common.py`: Shared utilities and configuration loader (required).
+- `config/`: Directory containing `params.json` (settings) and `text_en.json` (instructions).
+- `Abstract Stimuli/apophysis/`: Folder containing at least 24 complex 3D fractal PNG images.
+- `data/`: Output directory for results (auto-created during execution).
 
 ## Practice Protocol Integration 
 
@@ -64,7 +66,16 @@ Execute five sequential (5 minutes each), four spatial (4.5 minutes each), and f
 Save results per block and at the end in the data/ directory (e.g., participant_<ID>_n<level>_results.csv).
 
 ## Monitor Configuration
-Update the MONITOR_NAME variable in WAND_full_induction.py to match your lab’s monitor profile in PsychoPy’s Monitor Center for accurate stimulus sizing. The default is 'testMonitor'. See PsychoPy’s documentation for setup instructions.
+For accurate stimulus sizing, update the monitor settings in `config/params.json` to match your lab’s monitor profile (from PsychoPy’s Monitor Center).
+
+Edit the `"window"` section:
+```json
+"window": {
+  "monitor": "myLabMonitor",
+  "size": [1920, 1080],
+  "fullscreen": true,
+  ...
+}
 
 ## EEG Notes
 EEG triggers are implemented as placeholders. To enable, set EEG_ENABLED = True in the script and modify the send_trigger function to interface with your EEG hardware (e.g., via a parallel port). Currently, send_trigger includes a 5ms delay as a dummy operation. Future integration will target N2 and P3 ERP components to assess cognitive control decline.
@@ -85,7 +96,7 @@ How effortful do you find the task at this moment?
 Do you currently find your mind wandering or becoming distracted?
 How overwhelmed do you feel by the task demands right now?
 
-These measures, saved in the data/ directory (e.g., participant_<ID>_subjective_<timestamp>.csv), complement behavioural data to assess active fatigue.
+These responses are **integrated into the main results CSV** (`participant_<ID>_n<level>_results.csv`) at the end of the experiment.
 
 ## Testing
 

--- a/config/params.json
+++ b/config/params.json
@@ -3,7 +3,7 @@
     "fullscreen": false,
     "size": [1650, 1000],
     "monitor": "testMonitor",
-    "background_color": "black",
+    "background_color": [-1, -1, -1],
     "color_space": "rgb",
     "use_fbo": true
   },
@@ -41,7 +41,7 @@
     "levels": {
       "2": "deepskyblue",
       "3": "orange",
-      "4": "crimson"
+      "4": "teal"
     }
   }
 }

--- a/wand_analysis.py
+++ b/wand_analysis.py
@@ -1,0 +1,239 @@
+"""
+wand_analysis.py
+
+Behavioural metrics helpers for WAND.
+
+This module contains functions for computing signal-detection and basic
+performance metrics from trial-level data. It is imported by
+WAND_full_induction.py and can also be reused for offline analyses.
+
+Author
+------
+Brodie E. Mangan
+
+License
+-------
+MIT (see LICENSE).
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+from scipy.stats import norm
+
+
+def calculate_A_prime(trials: List[Dict[str, Any]]) -> Optional[float]:
+    """
+    Compute the A′ (A-prime) nonparametric sensitivity index for a set of trials.
+
+    Trials must contain:
+      - "Is Target": bool
+      - "Response": str in {"match", "non-match", "lapse"}.
+    """
+    if not trials:
+        return None
+
+    hits = 0
+    false_alarms = 0
+    misses = 0
+    correct_rejections = 0
+
+    for t in trials:
+        is_target = t.get("Is Target", False)
+        response = t.get("Response")
+        said_match = response == "match"
+
+        if is_target and said_match:
+            hits += 1
+        elif is_target and not said_match:
+            misses += 1
+        elif (not is_target) and said_match:
+            false_alarms += 1
+        elif (not is_target) and (not said_match):
+            correct_rejections += 1
+
+    total_targets = hits + misses
+    total_non_targets = false_alarms + correct_rejections
+
+    if total_targets == 0 or total_non_targets == 0:
+        return None
+
+    hit_rate = hits / total_targets
+    fa_rate = false_alarms / total_non_targets
+
+    # Clip to avoid extreme values
+    hit_rate = min(max(hit_rate, 0.0001), 0.9999)
+    fa_rate = min(max(fa_rate, 0.0001), 0.9999)
+
+    if hit_rate >= fa_rate:
+        a_prime = 0.5 + ((hit_rate - fa_rate) * (1 + hit_rate - fa_rate)) / (
+            4 * hit_rate * (1 - fa_rate)
+        )
+    else:
+        a_prime = 0.5 - ((fa_rate - hit_rate) * (1 + fa_rate - hit_rate)) / (
+            4 * fa_rate * (1 - hit_rate)
+        )
+
+    return a_prime
+
+
+def calculate_accuracy_and_rt(
+    trials: List[Dict[str, Any]],
+) -> Tuple[int, int, int, float, float, float]:
+    """
+    Compute accuracy (%), total RT, and average RT, plus counts.
+
+    This mirrors what you currently do in run_sequential_nback_block:
+      correct_responses, incorrect_responses, lapses,
+      total_reaction_time, avg_rt, accuracy (%).
+    """
+    if not trials:
+        return 0, 0, 0, 0.0, 0.0, 0.0
+
+    total_trials = len(trials)
+
+    correct = sum(1 for t in trials if t.get("Accuracy"))
+    lapses = sum(1 for t in trials if t.get("Response") == "lapse")
+    incorrect = total_trials - correct - lapses
+
+    total_responded = correct + incorrect + lapses
+    accuracy = (correct / total_responded) * 100 if total_responded else 0.0
+
+    rts = [t["Reaction Time"] for t in trials if t.get("Reaction Time") is not None]
+    total_rt = sum(rts)
+    avg_rt = total_rt / len(rts) if rts else 0.0
+
+    return correct, incorrect, lapses, total_rt, avg_rt, accuracy
+
+
+def calculate_dprime(detailed_data: List[Dict[str, Any]]) -> float:
+    """
+    Compute d′ (d-prime) with log-linear correction.
+
+    Trials must contain:
+      - "Is Target": bool
+      - "Response": str in {"match", "non-match", "lapse"}.
+    """
+    if not detailed_data:
+        return 0.0
+
+    hits = 0
+    false_alarms = 0
+    misses = 0
+    correct_rejections = 0
+
+    for t in detailed_data:
+        is_target = t.get("Is Target", False)
+        response = t.get("Response")
+        said_match = response == "match"
+
+        if is_target and said_match:
+            hits += 1
+        elif is_target and not said_match:
+            misses += 1
+        elif (not is_target) and said_match:
+            false_alarms += 1
+        elif (not is_target) and (not said_match):
+            correct_rejections += 1
+
+    total_targets = hits + misses
+    total_non_targets = false_alarms + correct_rejections
+
+    if total_targets == 0 or total_non_targets == 0:
+        return 0.0
+
+    # Log-linear correction
+    hit_rate = (hits + 0.5) / (total_targets + 1)
+    fa_rate = (false_alarms + 0.5) / (total_non_targets + 1)
+
+    try:
+        d_prime = norm.ppf(hit_rate) - norm.ppf(fa_rate)
+    except ValueError:
+        d_prime = 0.0
+
+    return d_prime
+
+
+def _window_metrics(
+    trials: List[Dict[str, Any]],
+) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+    """
+    Internal helper: accuracy, avg RT, A′ for a subset of trials.
+
+    Returns (accuracy_percent, avg_rt, a_prime) or (None, None, None) if no trials.
+    """
+    if not trials:
+        return None, None, None
+
+    _, _, _, _, avg_rt, accuracy = calculate_accuracy_and_rt(trials)
+    a_prime = calculate_A_prime(trials)
+    return accuracy, avg_rt, a_prime
+
+
+def summarise_sequential_block(
+    detailed_data: List[Dict[str, Any]],
+    distractor_trials: List[int],
+    block_number: int,
+) -> Dict[str, Any]:
+    """
+    Compute all block-level metrics for a Sequential N-back block.
+
+    This replicates the logic that used to live at the end of
+    run_sequential_nback_block in WAND_full_induction.py:
+      - global accuracy, total RT, average RT
+      - pre/post distractor accuracy, RT, A′
+      - overall d′
+    """
+    total_trials = len(detailed_data)
+
+    # Overall counts and RT
+    (
+        correct_responses,
+        incorrect_responses,
+        lapses,
+        total_rt,
+        avg_rt,
+        accuracy,
+    ) = calculate_accuracy_and_rt(detailed_data)
+
+    # Pre / post distractor windows
+    pre_indices: set[int] = set()
+    post_indices: set[int] = set()
+
+    for d in distractor_trials:
+        # 3 trials before the distractor
+        for j in range(d - 3, d):
+            if 1 <= j <= total_trials:
+                pre_indices.add(j)
+        # 3 trials after the distractor
+        for j in range(d + 1, d + 4):
+            if 1 <= j <= total_trials:
+                post_indices.add(j)
+
+    pre_data = [t for t in detailed_data if t["Trial"] in pre_indices]
+    post_data = [t for t in detailed_data if t["Trial"] in post_indices]
+
+    pre_acc, pre_rt, pre_ap = _window_metrics(pre_data)
+    post_acc, post_rt, post_ap = _window_metrics(post_data)
+
+    # This matches your original "reaction_times" list
+    reaction_times = [
+        t["Reaction Time"] for t in detailed_data if t.get("Reaction Time") is not None
+    ]
+
+    return {
+        "Block Number": block_number,
+        "Correct Responses": correct_responses,
+        "Incorrect Responses": incorrect_responses,
+        "Lapses": lapses,
+        "Accuracy": accuracy,
+        "Total Reaction Time": total_rt,
+        "Average Reaction Time": avg_rt,
+        "Reaction Times": reaction_times,
+        "Detailed Data": detailed_data,
+        "Pre-Distractor Accuracy": pre_acc if pre_acc is not None else "N/A",
+        "Pre-Distractor Avg RT": pre_rt if pre_rt is not None else "N/A",
+        "Pre-Distractor A-Prime": pre_ap if pre_ap is not None else "N/A",
+        "Post-Distractor Accuracy": post_acc if post_acc is not None else "N/A",
+        "Post-Distractor Avg RT": post_rt if post_rt is not None else "N/A",
+        "Post-Distractor A-Prime": post_ap if post_ap is not None else "N/A",
+        "Overall D-Prime": calculate_dprime(detailed_data),
+    }


### PR DESCRIPTION
## v1.0.4 Release Notes

### Added
- **Centralised behavioural analysis module**: `wand_analysis.py` now contains all Sequential N-back metrics (accuracy, average RT, A′, d′, and pre/post distractor window calculations). The induction script delegates all metric computation to this module.

### Changed
- **Extensive code deduplication and refactoring**:
    - **UI prompts**: Replaced ad-hoc text input with shared helpers `prompt_text_input()` and `prompt_choice()` in `wand_common.py`.
    - **Unified text-screen system**: All instruction/break screens now use `show_text_screen()`.
    - **Response loop unification**: All tasks use a centralised `collect_trial_response()` function.
    - **Sequence generation merged**: Sequential image generation is now handled by `generate_sequential_image_sequence()`.
- **Sequential N-back logic standardised**: Removed n−1 lures from 3-back; both levels now use ~50% target probability and max 2 consecutive matches.
- **Practical installation improvements**: README now includes `py` commands for Windows and pip upgrade instructions.
- **Neutral, non-competitive framing**: Practice instructions emphasise calibration over scoring; feedback is now qualitative/neutral.
- **Sequential practice target rate**: Raised from 0.4 → 0.5 to align with main induction.
- **Display configuration**: Window background forced to absolute black `[-1, -1, -1]` to fix rendering issues.

### Fixed
- **Sequential Practice Logic Conflict**: Resolved an edge case where high stability + high accuracy triggered plateau exit instead of promotion. Logic now prioritizes level promotion.
- **Text visibility**: Fixed issues where "black" was interpreted inconsistently by PsychoPy.

### Removed
- **Legacy on-screen scoreboards**: Removed `show_summary()` and `show_final_summary()` to prevent competitive score-chasing.
- **Obsolete inline metric helpers**: Deprecated in favour of `wand_analysis.py`.